### PR TITLE
remove mounted function and replace with inline click events

### DIFF
--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -3,36 +3,36 @@ import { defineComponent } from "@vue/runtime-core"
 import styles from './TitleBar.module.scss'
 
 const TitleBar = defineComponent({
-    mounted() {
-        document
-            ?.getElementById('titlebar-minimize')
-            ?.addEventListener('click', () => appWindow.minimize());
+    // mounted() {
+    //     document
+    //         ?.getElementById('titlebar-minimize')
+    //         ?.addEventListener('click', () => appWindow.minimize());
 
-        document
-            ?.getElementById('titlebar-maximize')
-            ?.addEventListener('click', () => appWindow.toggleMaximize());
+    //     document
+    //         ?.getElementById('titlebar-maximize')
+    //         ?.addEventListener('click', () => appWindow.toggleMaximize());
 
-        document
-            ?.getElementById('titlebar-close')
-            ?.addEventListener('click', () => appWindow.close());
-    },
+    //     document
+    //         ?.getElementById('titlebar-close')
+    //         ?.addEventListener('click', () => appWindow.close());
+    // },
     render() {
         return <div data-tauri-drag-region class={styles.titlebar}>
             <span class={styles.titlebarText}>{this.title}</span>
             <div>
-                <div class={styles.titlebarButton} id="titlebar-minimize">
+                <div class={styles.titlebarButton} id="titlebar-minimize" onClick={() => appWindow.minimize()}>
                     <img
                     src="https://api.iconify.design/mdi:window-minimize.svg"
                     alt="minimize"
                     />
                 </div>
-                <div class={styles.titlebarButton} id="titlebar-maximize">
+                <div class={styles.titlebarButton} id="titlebar-maximize" onClick={() => appWindow.toggleMaximize()}>
                     <img
                     src="https://api.iconify.design/mdi:window-maximize.svg"
                     alt="maximize"
                     />
                 </div>
-                <div class={styles.titlebarButtonClose} id="titlebar-close">
+                <div class={styles.titlebarButtonClose} id="titlebar-close" onClick={() => appWindow.close()}>
                     <img src="https://api.iconify.design/mdi:close.svg" alt="close" />
                 </div>
             </div>


### PR DESCRIPTION
In theory, some mounted stuff should be in the `setup` part of this, but I think opting for inline click event listeners is probably better here?