### PR TITLE
Set css settings so we can have 'standard' css

### DIFF
--- a/src/components/TitleBar/TitleBar.module.scss
+++ b/src/components/TitleBar/TitleBar.module.scss
@@ -13,7 +13,7 @@ $button-width: 46px;
     right: 0;
 }
 
-.titlebarText {
+.titlebar-text {
     margin: auto;
     padding: 0;
     padding-left: $button-width * 3;
@@ -22,7 +22,7 @@ $button-width: 46px;
     color: #000;
 }
 
-.titlebarButton, .titlebarButtonClose {
+.titlebar-button, .titlebar-button-close {
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -30,12 +30,12 @@ $button-width: 46px;
     height: $button-height;
 }
   
-.titlebarButton:hover {
+.titlebar-button:hover {
     background: #158f58;
     transition-duration: 200ms;
 }
 
-.titlebarButtonClose:hover {
+.titlebar-button-close:hover {
     background: #ea2820;
     transition-duration: 200ms;
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    css: {
+      loaderOptions: {
+        css: {
+          localsConvention: 'camelCaseOnly'
+        }
+      }
+    }
+  }


### PR DESCRIPTION
Per vue docs on customizing build [here](https://cli.vuejs.org/guide/css.html#css-modules), I enabled a setting that allows you to write css like

```css
.some-class-name {
```

and use it like

```jsx
<div class={styles.someClassName}>
```

There may be another setting that is more desirable, so look [here](https://github.com/webpack-contrib/css-loader#exportLocalsConvention) and give feedback?