### PR TITLE
fix(xl): Compile error after merge

### DIFF
--- a/src-libxl/src/process/mod.rs
+++ b/src-libxl/src/process/mod.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use std::process::Command;
 use sysinfo::{Pid, ProcessExt, System, SystemExt};
 


### PR DESCRIPTION
Missing `use lazy_static::lazy_static` after removing macro from global
scope.

As I work on bringing DalamudLauncher/Update to Neo, I naturally also look into how best handles processes.
There might be some overlap.